### PR TITLE
chore: 🤖 release 0.8.2

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ coverage
 dist
 lib
 CHANGELOG.md
+.history


### PR DESCRIPTION
fix: 🐛 bean object is not correctly gc after component unmount